### PR TITLE
Change to function types and additions of required casts

### DIFF
--- a/src/acshudlib.acs
+++ b/src/acshudlib.acs
@@ -514,34 +514,34 @@ function void HudSetCenterText(bool centerText)
 	$R_CenterText = centerText;
 }
 
-function void HudSetAlignment(fixed alignX, fixed alignY)
+function void HudSetAlignment(int alignX, int alignY)
 {
 	$R_AlignX = alignX;
 	$R_AlignY = alignY;
 }
 
-function void HudSetAlign(fixed alignX, fixed alignY)
+function void HudSetAlign(int alignX, int alignY)
 {
 	$R_AlignX = alignX;
 	$R_AlignY = alignY;
 }
 
-function void HudSetAlignmentX(fixed alignX)
+function void HudSetAlignmentX(int alignX)
 {
 	$R_AlignX = alignX;
 }
 
-function void HudSetAlignX(fixed alignX)
+function void HudSetAlignX(int alignX)
 {
 	$R_AlignX = alignX;
 }
 
-function void HudSetAlignmentY(fixed alignY)
+function void HudSetAlignmentY(int alignY)
 {
 	$R_AlignY = alignY;
 }
 
-function void HudSetAlignY(fixed alignY)
+function void HudSetAlignY(int alignY)
 {
 	$R_AlignY = alignY;
 }

--- a/src/acsinfo.acs
+++ b/src/acsinfo.acs
@@ -10,7 +10,7 @@ function int IdentifySourcePort(void)
 	if ($CachedPort != -1)
 		return $CachedPort;
 
-	if (GetPlayerAccountName(0) != 0)
+	if ((raw)GetPlayerAccountName(0) != 0)
 	{
 		// GetPlayerAccountName returns a string (possibly empty) in Zandronum
 		// but 0 in GZDoom.
@@ -19,7 +19,7 @@ function int IdentifySourcePort(void)
 	}
 	
 	int tid = UniqueTid();
-	if (SpawnForced("DynamicLight", 0, 0, 0, tid))
+	if (SpawnForced("DynamicLight", 0.0, 0.0, 0.0, tid))
 	{
 		// DynamicLight is a built-in actor in GZDoom.
 		Thing_Remove(tid);

--- a/src/acsmath.acs
+++ b/src/acsmath.acs
@@ -32,7 +32,7 @@ function num max(num a, num b)
 	return b;
 }
 
-function int clamp(num x, num a, num b)
+function num clamp(num x, num a, num b)
 {
 	if (x > b)
 		return b;
@@ -50,7 +50,7 @@ function int sgn(num x)
 	return 0;
 }
 
-function int abs(num x)
+function num abs(num x)
 {
 	if (x > 0)
 		return x;

--- a/src/acsplayer.acs
+++ b/src/acsplayer.acs
@@ -16,7 +16,7 @@ function int ActorPlayerNumber(int tid)
 
 function bool ActorIsPlayer(int tid)
 {
-	return ClassifyActor(tid) & ACTOR_PLAYER;
+	return bool(ClassifyActor(tid) & ACTOR_PLAYER);
 }
 
 function str PlayerName(int player)

--- a/src/acszdoom.acs
+++ b/src/acszdoom.acs
@@ -114,7 +114,7 @@ script "ACSUtils_GetActorName" (int tid)
 
 function str GetActorName(int tid)
 {
-	return ACS_NamedExecuteWithResult("ACSUtils_GetActorName", tid);
+	return str(ACS_NamedExecuteWithResult("ACSUtils_GetActorName", tid));
 }
 
 function bool IsAlive(void)


### PR DESCRIPTION
These aim to fix compilation errors for zt-bcc.
Important: These changes will cause ACC-compatibility to break. The addition of the implicit cast to `(raw)` on `GetPlayerAccountName` is not yet supported and will not work when compiling.